### PR TITLE
add varparallel and nvarparallel

### DIFF
--- a/TeXmacs/fonts/virtual/emu-relations.vfn
+++ b/TeXmacs/fonts/virtual/emu-relations.vfn
@@ -82,4 +82,7 @@
   (nVvDash (with d (+ (sep-equal) (width verbar))
              (join (reslash (crop slash) (crop VvDash)) (d 0 VvDash))))
   (nDashVv (with d (+ (sep-equal) (width verbar))
-             (join DashVv (d 0 (reslash (crop slash) (crop DashVv)))))))
+             (join DashVv (d 0 (reslash (crop slash) (crop DashVv))))))
+  (varparallel (with d (+ (sep-equal) (width verbar))
+           (join slash (d 0 slash))))
+  (nvarparallel (join varparallel (rotate (hor-scale minus varparallel) 0.32))))

--- a/TeXmacs/progs/language/std-symbols.scm
+++ b/TeXmacs/progs/language/std-symbols.scm
@@ -106,6 +106,7 @@
     "<subsetsim>" "<supsetsim>" "<doteq>" "<propto>" "<varpropto>"
     "<perp>" "<bowtie>" "<Join>" "<smile>" "<frown>" "<signchange>"
     "<parallel>" "<shortparallel>" "<nparallel>" "<nshortparallel>"
+    "<varparallel>" "<nvarparallel>"
     "<shortmid>" "<nshortmid>" "<nmid>" "<divides>" "<ndivides>"
 
     "<approxeq>" "<backsim>" "<backsimeq>"

--- a/TeXmacs/progs/math/math-kbd.scm
+++ b/TeXmacs/progs/math/math-kbd.scm
@@ -408,6 +408,8 @@
   ("symbol | | /" "<nparallel>")
   ("symbol | | var" "<shortparallel>")
   ("symbol | | var /" "<nshortparallel>")
+  ("symbol | | var var" "<varparallel>")
+  ("symbol | | var var /" "<nvarparallel>")
 
   ("math:small (" (math-bracket-open "(" ")" #f))
   ("math:small ( var" (math-bracket-open "<nobracket>" "<nobracket>" #f))
@@ -1396,6 +1398,8 @@
   ("| | var var /" "<nparallel>")
   ("| | var var var" "<shortparallel>")
   ("| | var var var /" "<nshortparallel>")
+  ("| | var var var var" "<varparallel>")
+  ("| | var var var var /" "<nvarparallel>")
   ("| | | var" "<interleave>")
 
   ("| - var" "<vdash>")
@@ -1594,6 +1598,8 @@
   ("math:misc | | /" "<nparallel>")
   ("math:misc | | var" "<shortparallel>")
   ("math:misc | | var /" "<nshortparallel>")
+  ("math:misc | | var var" "<varparallel>")
+  ("math:misc | | var var /" "<nvarparallel>")
 
   ("math:greek a" "<alpha>")
   ("math:greek b" "<beta>")

--- a/TeXmacs/progs/texmacs/keyboard/latex-kbd.scm
+++ b/TeXmacs/progs/texmacs/keyboard/latex-kbd.scm
@@ -111,7 +111,7 @@
   "shortparallel" "smallsetminus" "thicksim" "thickapprox"
   "approxeq" "succapprox" "precapprox" "curvearrowleft"
   "curvearrowright" "digamma" "varkappa" "hslash"
-  "hbar" "backepsilon"
+  "hbar" "backepsilon" "varparallel" "nvarparallel"
   
   "mapsto" "longmapsto" "longrightarrow" "longleftarrow"
   "longleftrightarrow" "longRightarrow" "longLeftarrow"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What
Add `\varparallel` and `\nvarparallel`.

## Why
These symbols are widely used in plane and solid geometry.

## How to test your changes?
Use `\varparallel` and `\nvarparallel` in math mode.
![image](https://github.com/KeShih/mogan/assets/109031129/337e5706-ab87-4c81-aca6-54e5f7bb71bf)
